### PR TITLE
Fixed returning data range

### DIFF
--- a/request-processor.js
+++ b/request-processor.js
@@ -242,7 +242,7 @@ function filterDataPeriod(data, fromSeconds, toSeconds) {
 		s = 'no_data';
 	}
 
-	toIndex = Math.min(fromIndex + 1000, toIndex); // do not send more than 1000 bars for server capacity reasons
+	fromIndex = Math.max(fromIndex, toIndex - 1000); // do not send more than 1000 bars for server capacity reasons
 
 	return {
 		t: data.t.slice(fromIndex, toIndex),


### PR DESCRIPTION
If we response data since "from" time (with limit 1000 bars), it leads the chart doesn't load skipped data range.
Thus, it'd be better to filter out data since "to" date, so chart will be able to load data prior _returned_ "from" date (first returned item).